### PR TITLE
Fix stamp size persistence

### DIFF
--- a/app/Http/Controllers/BookController.php
+++ b/app/Http/Controllers/BookController.php
@@ -390,6 +390,8 @@ class BookController extends Controller
         $positionX = $request->input('positionX');
         $positionY = $request->input('positionY');
         $positionPages = $request->input('positionPages');
+        $width = $request->input('width');
+        $height = $request->input('height');
         $pages = $request->input('pages');
         $query = new Book;
         $book = $query->where('id', $id)->first();
@@ -409,7 +411,7 @@ class BookController extends Controller
                     'detail' => 'ลงบันทึกรับหนังสือ',
                     'book_id' => $id
                 ]);
-                $this->editPdf($positionX, $positionY, $pages, $book, $positionPages);
+                $this->editPdf($positionX, $positionY, $pages, $book, $positionPages, $width, $height);
                 $filePath =  'uploads/' . rand(1, 10000) . time() . '.pdf';
                 rename(storage_path('app/public/' . $book->file), storage_path('app/public/' . $filePath));
                 $update->file = $filePath;
@@ -421,7 +423,7 @@ class BookController extends Controller
         return response()->json($data);
     }
 
-    public function editPdf($x, $y, $pages, $data, $positionPages)
+    public function editPdf($x, $y, $pages, $data, $positionPages, $widthPx, $heightPx)
     {
         $filePath = public_path('/storage/' . $data->file);
 
@@ -448,23 +450,23 @@ class BookController extends Controller
                     $pdf->AddFont('sarabunextralight', '', $fontPath);
                     $pdf->setTextColor(0, 0, 255);
                     $pdf->setDrawColor(0, 0, 255);
+                    $scale = min($widthPx / 213, $heightPx / 115);
                     $x = ($x / 1.5) * 0.3528;
                     $y = ($y / 1.5) * 0.3528;
-                    $width = 50;
-                    $height = 27;
+                    $width = ($widthPx / 1.5) * 0.3528;
+                    $height = ($heightPx / 1.5) * 0.3528;
                     $pdf->Rect($x, $y, $width, $height);
-                    $pdf->SetFont('sarabunextralight', '', 10);
-                    $pdf->Text($x + 1, $y + 2, 'องค์การบริหารส่วนตำบลแปลงยาว');
-                    $pdf->Text($x + 21, $y + 8.5, numberToThaiDigits($data->inputBookregistNumber));
-                    $pdf->SetFont('sarabunextralight', '', 8);
-                    $pdf->Text($x + 1, $y + 10, 'รับที่.................................................................');
-                    $pdf->Text($x + 8, $y + 15, convertDayToThai($data->inputRecieveDate));
-                    $pdf->Text($x + 19.5, $y + 15, convertMonthsToThai($data->inputRecieveDate));
-                    $pdf->Text($x + 39, $y + 15, convertYearsToThai($data->inputRecieveDate));
-                    $pdf->Text($x + 1, $y + 16, 'วันที่...........เดือน........................พ.ศ..............');
-                    $pdf->Text($x + 19, $y + 20, convertTimeToThai(date('H:i:s', strtotime($data->inputRecieveDate))));
-                    $pdf->Text($x + 1, $y + 21, 'เวลา.............................................................น.');
-
+                    $pdf->SetFont('sarabunextralight', '', 10 * $scale);
+                    $pdf->Text($x + (1 * $scale), $y + (2 * $scale), 'องค์การบริหารส่วนตำบลแปลงยาว');
+                    $pdf->Text($x + (21 * $scale), $y + (8.5 * $scale), numberToThaiDigits($data->inputBookregistNumber));
+                    $pdf->SetFont('sarabunextralight', '', 8 * $scale);
+                    $pdf->Text($x + (1 * $scale), $y + (10 * $scale), 'รับที่.............................................................');
+                    $pdf->Text($x + (8 * $scale), $y + (15 * $scale), convertDayToThai($data->inputRecieveDate));
+                    $pdf->Text($x + (19.5 * $scale), $y + (15 * $scale), convertMonthsToThai($data->inputRecieveDate));
+                    $pdf->Text($x + (39 * $scale), $y + (15 * $scale), convertYearsToThai($data->inputRecieveDate));
+                    $pdf->Text($x + (1 * $scale), $y + (16 * $scale), 'วันที่...........เดือน...................พ.ศ..............');
+                    $pdf->Text($x + (19 * $scale), $y + (20 * $scale), convertTimeToThai(date("H:i:s", strtotime($data->inputRecieveDate))));
+                    $pdf->Text($x + (1 * $scale), $y + (21 * $scale), 'เวลา..........................................................น.');
                     $stop_++;
                 }
             } else {
@@ -473,23 +475,23 @@ class BookController extends Controller
                     $pdf->AddFont('sarabunextralight', '', $fontPath);
                     $pdf->setTextColor(0, 0, 255);
                     $pdf->setDrawColor(0, 0, 255);
+                    $scale = min($widthPx / 213, $heightPx / 115);
                     $x = ($x / 1.5) * 0.3528;
                     $y = ($y / 1.5) * 0.3528;
-                    $width = 50;
-                    $height = 27;
+                    $width = ($widthPx / 1.5) * 0.3528;
+                    $height = ($heightPx / 1.5) * 0.3528;
                     $pdf->Rect($x, $y, $width, $height);
-                    $pdf->SetFont('sarabunextralight', '', 10);
-                    $pdf->Text($x + 1, $y + 2, 'องค์การบริหารส่วนตำบลแปลงยาว');
-                    $pdf->Text($x + 21, $y + 8.5, numberToThaiDigits($data->inputBookregistNumber));
-                    $pdf->SetFont('sarabunextralight', '', 8);
-                    $pdf->Text($x + 1, $y + 10, 'รับที่.................................................................');
-                    $pdf->Text($x + 8, $y + 15, convertDayToThai($data->inputRecieveDate));
-                    $pdf->Text($x + 19.5, $y + 15, convertMonthsToThai($data->inputRecieveDate));
-                    $pdf->Text($x + 39, $y + 15, convertYearsToThai($data->inputRecieveDate));
-                    $pdf->Text($x + 1, $y + 16, 'วันที่...........เดือน........................พ.ศ..............');
-                    $pdf->Text($x + 19, $y + 20, convertTimeToThai(date('H:i:s', strtotime($data->inputRecieveDate))));
-                    $pdf->Text($x + 1, $y + 21, 'เวลา.............................................................น.');
-                }
+                    $pdf->SetFont('sarabunextralight', '', 10 * $scale);
+                    $pdf->Text($x + (1 * $scale), $y + (2 * $scale), 'องค์การบริหารส่วนตำบลแปลงยาว');
+                    $pdf->Text($x + (21 * $scale), $y + (8.5 * $scale), numberToThaiDigits($data->inputBookregistNumber));
+                    $pdf->SetFont('sarabunextralight', '', 8 * $scale);
+                    $pdf->Text($x + (1 * $scale), $y + (10 * $scale), 'รับที่.............................................................');
+                    $pdf->Text($x + (8 * $scale), $y + (15 * $scale), convertDayToThai($data->inputRecieveDate));
+                    $pdf->Text($x + (19.5 * $scale), $y + (15 * $scale), convertMonthsToThai($data->inputRecieveDate));
+                    $pdf->Text($x + (39 * $scale), $y + (15 * $scale), convertYearsToThai($data->inputRecieveDate));
+                    $pdf->Text($x + (1 * $scale), $y + (16 * $scale), 'วันที่...........เดือน...................พ.ศ..............');
+                    $pdf->Text($x + (19 * $scale), $y + (20 * $scale), convertTimeToThai(date("H:i:s", strtotime($data->inputRecieveDate))));
+                    $pdf->Text($x + (1 * $scale), $y + (21 * $scale), 'เวลา..........................................................น.');
             }
         }
 

--- a/resources/views/book/js/show.blade.php
+++ b/resources/views/book/js/show.blade.php
@@ -140,6 +140,8 @@
             $('#positionX').val(startX);
             $('#positionY').val(startY);
             $('#positionPages').val(1);
+            $('#positionWidth').val(defaultWidth);
+            $('#positionHeight').val(defaultHeight);
 
             drawTextHeader('15px Sarabun', startX + 3, startY + 25, 'องค์การบริหารส่วนตำบลแปลงยาว');
             drawTextHeader('12px Sarabun', startX + 8, startY + 55, 'รับที่..........................................................');
@@ -158,6 +160,8 @@
                 // Calculate scale for both box and text based on current box size
                 var boxW = markCoordinates.endX - markCoordinates.startX;
                 var boxH = markCoordinates.endY - markCoordinates.startY;
+                $('#positionWidth').val(boxW);
+                $('#positionHeight').val(boxH);
                 var defaultWidth = 213;
                 var defaultHeight = 115;
                 // Use the smaller scale of width/height to keep aspect ratio
@@ -324,6 +328,8 @@
                 $('#positionX').val(startX);
                 $('#positionY').val(startY);
                 $('#positionPages').val(2);
+                $('#positionWidth').val(213);
+                $('#positionHeight').val(115);
 
                 drawTextHeaderInsert('15px Sarabun', startX + 3, startY + 25, 'องค์การบริหารส่วนตำบลแปลงยาว');
                 drawTextHeaderInsert('12px Sarabun', startX + 8, startY + 55, 'รับที่..........................................................');
@@ -379,6 +385,8 @@
             $('#positionX').val('');
             $('#positionY').val('');
             $('#positionPages').val('');
+            $('#positionWidth').val('');
+            $('#positionHeight').val('');
         }
 
         // ฟังก์ชันในการวาดกากบาทเล็กๆ ที่มุมขวาบน
@@ -572,6 +580,11 @@
             markCanvasInsert.removeEventListener('click', markEventListenerInsert);
             markEventListenerInsert = null;
         }
+        $('#positionX').val('');
+        $('#positionY').val('');
+        $('#positionPages').val('');
+        $('#positionWidth').val('');
+        $('#positionHeight').val('');
     }
 
     function resetMarking() {
@@ -689,6 +702,8 @@
         var positionX = $('#positionX').val();
         var positionY = $('#positionY').val();
         var positionPages = $('#positionPages').val();
+        var positionWidth = $('#positionWidth').val();
+        var positionHeight = $('#positionHeight').val();
         var pages = $('#page-select').find(":selected").val();
         if (id != '' && positionX != '' && positionY != '') {
             Swal.fire({
@@ -707,6 +722,8 @@
                             positionX: positionX,
                             positionY: positionY,
                             positionPages: positionPages,
+                            width: positionWidth,
+                            height: positionHeight,
                             pages: pages
                         },
                         dataType: "json",

--- a/resources/views/book/show.blade.php
+++ b/resources/views/book/show.blade.php
@@ -195,6 +195,8 @@
     <input type="hidden" name="positionX" id="positionX">
     <input type="hidden" name="positionY" id="positionY">
     <input type="hidden" name="positionPages" id="positionPages">
+    <input type="hidden" name="positionWidth" id="positionWidth">
+    <input type="hidden" name="positionHeight" id="positionHeight">
 </div>
 <div class="offcanvas offcanvas-start" style="width:30%" data-bs-scroll="true" data-bs-backdrop="false" tabindex="-1" id="offcanvasScrolling" aria-labelledby="offcanvasScrollingLabel">
     <div class="offcanvas-header">


### PR DESCRIPTION
## Summary
- preserve custom stamp size when saving
- store width & height on the frontend and pass to backend
- handle width & height in the stamp controller
- scale PDF stamp text when box size changes

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866585a5f3c8329bab2dfc15fd5f69d