### PR TITLE
Fix stamp resizing

### DIFF
--- a/app/Http/Controllers/BookController.php
+++ b/app/Http/Controllers/BookController.php
@@ -615,6 +615,8 @@ class BookController extends Controller
         $positionX = $request->input('positionX');
         $positionY = $request->input('positionY');
         $positionPages = $request->input('positionPages');
+        $width = $request->input('width');
+        $height = $request->input('height');
         $pages = $request->input('pages');
         $query = new Book;
         $book = $query->where('id', $id)->first();
@@ -625,7 +627,7 @@ class BookController extends Controller
             $update->adminBookNumber = adminNumber();
             $update->adminDated = date('Y-m-d H:i:s');
             if ($update->save()) {
-                $this->editPdf_admin($positionX, $positionY, $pages, $update, $positionPages);
+                $this->editPdf_admin($positionX, $positionY, $pages, $update, $positionPages, $width, $height);
                 if ($positionPages == 2) {
                     if ($update->new_pages != 0) {
                         $update->new_pages = $update->new_pages + 1;
@@ -653,7 +655,7 @@ class BookController extends Controller
         return response()->json($data);
     }
 
-    public function editPdf_admin($x, $y, $pages, $data, $positionPages)
+    public function editPdf_admin($x, $y, $pages, $data, $positionPages, $widthPx, $heightPx)
     {
 
         $permission_name = $this->position_name;
@@ -702,13 +704,14 @@ class BookController extends Controller
                         $pdf->AddFont('sarabunextralight', '', $fontPath);
                         $pdf->setTextColor(0, 0, 255);
                         $pdf->setDrawColor(0, 0, 255);
+                        $scale = min($widthPx / 213, $heightPx / 115);
                         $x = ($x / 1.5) * 0.3528;
                         $y = ($y / 1.5) * 0.3528;
-                        $width = 50;
-                        $height = 27;
+                        $width = ($widthPx / 1.5) * 0.3528;
+                        $height = ($heightPx / 1.5) * 0.3528;
                         $pdf->Rect($x, $y, $width, $height);
-                        $pdf->SetFont('sarabunextralight', '', 10);
-                        $pdf->Text($x + $dynamicX, $y + 2, $permission_name);
+                        $pdf->SetFont('sarabunextralight', '', 10 * $scale);
+                        $pdf->Text($x + ($dynamicX * $scale), $y + (2 * $scale), $permission_name);
                         $pdf->Text($x + 21, $y + 8.5, numberToThaiDigits($data['adminBookNumber']));
                         $pdf->SetFont('sarabunextralight', '', 8);
                         $pdf->Text($x + 1, $y + 10, 'รับที่.................................................................');
@@ -728,13 +731,14 @@ class BookController extends Controller
                     $pdf->AddFont('sarabunextralight', '', $fontPath);
                     $pdf->setTextColor(0, 0, 255);
                     $pdf->setDrawColor(0, 0, 255);
+                    $scale = min($widthPx / 213, $heightPx / 115);
                     $x = ($x / 1.5) * 0.3528;
                     $y = ($y / 1.5) * 0.3528;
-                    $width = 50;
-                    $height = 27;
+                    $width = ($widthPx / 1.5) * 0.3528;
+                    $height = ($heightPx / 1.5) * 0.3528;
                     $pdf->Rect($x, $y, $width, $height);
-                    $pdf->SetFont('sarabunextralight', '', 10);
-                    $pdf->Text($x + $dynamicX, $y + 2, $permission_name);
+                    $pdf->SetFont('sarabunextralight', '', 10 * $scale);
+                    $pdf->Text($x + ($dynamicX * $scale), $y + (2 * $scale), $permission_name);
                     $pdf->Text($x + 21, $y + 8.5, numberToThaiDigits($data['adminBookNumber']));
                     $pdf->SetFont('sarabunextralight', '', 8);
                     $pdf->Text($x + 1, $y + 10, 'รับที่.................................................................');

--- a/resources/views/book/js/admin.blade.php
+++ b/resources/views/book/js/admin.blade.php
@@ -141,6 +141,8 @@
             $('#positionX').val(startX);
             $('#positionY').val(startY);
             $('#positionPages').val(1);
+            $('#positionWidth').val(defaultWidth);
+            $('#positionHeight').val(defaultHeight);
 
             var text = '{{$position_name}}';
             var dynamicX;
@@ -176,6 +178,8 @@
                 var boxH = markCoordinates.endY - markCoordinates.startY;
                 var defaultWidth = 213;
                 var defaultHeight = 115;
+                $('#positionWidth').val(boxW);
+                $('#positionHeight').val(boxH);
                 // Use the smaller scale of width/height to keep aspect ratio
                 var scaleW = boxW / defaultWidth;
                 var scaleH = boxH / defaultHeight;
@@ -356,6 +360,8 @@
                 $('#positionX').val(startX);
                 $('#positionY').val(startY);
                 $('#positionPages').val(2);
+                $('#positionWidth').val(213);
+                $('#positionHeight').val(115);
 
                 var text = '{{$position_name}}';
                 var dynamicX;
@@ -832,6 +838,11 @@
             markCanvasInsert.removeEventListener('click', markEventListenerInsert);
             markEventListenerInsert = null;
         }
+        $('#positionX').val('');
+        $('#positionY').val('');
+        $('#positionPages').val('');
+        $('#positionWidth').val('');
+        $('#positionHeight').val('');
     }
 
     function resetMarking() {
@@ -965,6 +976,8 @@
         var positionX = $('#positionX').val();
         var positionY = $('#positionY').val();
         var positionPages = $('#positionPages').val();
+        var positionWidth = $('#positionWidth').val();
+        var positionHeight = $('#positionHeight').val();
         var pages = $('#page-select').find(":selected").val();
         if (id != '' && positionX != '' && positionY != '') {
             Swal.fire({
@@ -983,6 +996,8 @@
                             positionX: positionX,
                             positionY: positionY,
                             positionPages: positionPages,
+                            width: positionWidth,
+                            height: positionHeight,
                             pages: pages
                         },
                         dataType: "json",


### PR DESCRIPTION
## Summary
- support custom stamp size when admins save stamped documents
- track stamp width/height on the client when drawing
- scale permission label position based on stamp size

## Testing
- `php artisan test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6866b0005b7483298429ff89a18ffb69