### PR TITLE
feat: allow rejecting documents

### DIFF
--- a/app/Http/Controllers/DirectoryController.php
+++ b/app/Http/Controllers/DirectoryController.php
@@ -70,14 +70,6 @@ class DirectoryController extends Controller
             }
         }
         ksort($data['item']);
-        $data['reject'] = [];
-        foreach ($data['item'] as $id => $name) {
-            $count = Directory_log::leftJoin('log_status_books', 'log_status_books.id', '=', 'directory_logs.logs_id')
-                ->where('directory_logs.position_id', $id)
-                ->where('log_status_books.status', 16)
-                ->count();
-            $data['reject'][$id] = $count > 0;
-        }
 
         return view('directory.index', $data);
     }

--- a/resources/views/book/js/admin.blade.php
+++ b/resources/views/book/js/admin.blade.php
@@ -1335,7 +1335,7 @@
                 document.getElementById('directory-save').disabled = false;
                 $('#directory-save').show();
             }
-            if (status >= 3 && status < 15) {
+            if (status > 1 && status < 15) {
                 document.getElementById('reject-book').disabled = false;
                 $('#reject-book').show();
             }

--- a/resources/views/book/js/bailiff.blade.php
+++ b/resources/views/book/js/bailiff.blade.php
@@ -409,6 +409,10 @@
             $('#manager-send').show();
             $('#send-save').show();
         }
+        if (status > 1 && status < 15) {
+            document.getElementById('reject-book').disabled = false;
+            $('#reject-book').show();
+        }
         resetMarking();
         removeMarkListener();
     }
@@ -707,6 +711,55 @@
         $('#insert-pages').click(function(e) {
             e.preventDefault();
             $('#insert_tab').show();
+        });
+
+        $('#reject-book').click(function (e) {
+            e.preventDefault();
+            Swal.fire({
+                title: "",
+                text: "ยืนยันการปฏิเสธหนังสือหรือไม่",
+                icon: "warning",
+                input: 'textarea',
+                inputPlaceholder: 'กรอกเหตุผลการปฏิเสธ',
+                showCancelButton: true,
+                confirmButtonColor: "#3085d6",
+                cancelButtonColor: "#d33",
+                cancelButtonText: "ยกเลิก",
+                confirmButtonText: "ตกลง",
+                preConfirm: (note) => {
+                    if (!note) {
+                        Swal.showValidationMessage('กรุณากรอกเหตุผล');
+                    }
+                    return note;
+                }
+            }).then((result) => {
+                if (result.isConfirmed) {
+                    var id = $('#id').val();
+                    var note = result.value;
+                    $.ajax({
+                        type: "post",
+                        url: "/book/reject",
+                        data: {
+                            id: id,
+                            note: note,
+                        },
+                        dataType: "json",
+                        headers: {
+                            'X-CSRF-TOKEN': '{{ csrf_token() }}'
+                        },
+                        success: function (response) {
+                            if (response.status) {
+                                Swal.fire("", "ปฏิเสธเรียบร้อย", "success");
+                                setTimeout(() => {
+                                    location.reload();
+                                }, 1500);
+                            } else {
+                                Swal.fire("", "ปฏิเสธไม่สำเร็จ", "error");
+                            }
+                        }
+                    });
+                }
+            });
         });
 
         async function createAndRenderPDF() {

--- a/resources/views/book/js/manager.blade.php
+++ b/resources/views/book/js/manager.blade.php
@@ -409,6 +409,10 @@
             $('#manager-send').show();
             $('#send-save').show();
         }
+        if (status > 1 && status < 15) {
+            document.getElementById('reject-book').disabled = false;
+            $('#reject-book').show();
+        }
         resetMarking();
         removeMarkListener();
     }
@@ -703,6 +707,55 @@
         $('#insert-pages').click(function(e) {
             e.preventDefault();
             $('#insert_tab').show();
+        });
+
+        $('#reject-book').click(function (e) {
+            e.preventDefault();
+            Swal.fire({
+                title: "",
+                text: "ยืนยันการปฏิเสธหนังสือหรือไม่",
+                icon: "warning",
+                input: 'textarea',
+                inputPlaceholder: 'กรอกเหตุผลการปฏิเสธ',
+                showCancelButton: true,
+                confirmButtonColor: "#3085d6",
+                cancelButtonColor: "#d33",
+                cancelButtonText: "ยกเลิก",
+                confirmButtonText: "ตกลง",
+                preConfirm: (note) => {
+                    if (!note) {
+                        Swal.showValidationMessage('กรุณากรอกเหตุผล');
+                    }
+                    return note;
+                }
+            }).then((result) => {
+                if (result.isConfirmed) {
+                    var id = $('#id').val();
+                    var note = result.value;
+                    $.ajax({
+                        type: "post",
+                        url: "/book/reject",
+                        data: {
+                            id: id,
+                            note: note,
+                        },
+                        dataType: "json",
+                        headers: {
+                            'X-CSRF-TOKEN': '{{ csrf_token() }}'
+                        },
+                        success: function (response) {
+                            if (response.status) {
+                                Swal.fire("", "ปฏิเสธเรียบร้อย", "success");
+                                setTimeout(() => {
+                                    location.reload();
+                                }, 1500);
+                            } else {
+                                Swal.fire("", "ปฏิเสธไม่สำเร็จ", "error");
+                            }
+                        }
+                    });
+                }
+            });
         });
 
         async function createAndRenderPDF() {

--- a/resources/views/book/js/mayor_1.blade.php
+++ b/resources/views/book/js/mayor_1.blade.php
@@ -338,6 +338,10 @@
             $('#manager-send').show();
             $('#send-save').show();
         }
+        if (status > 1 && status < 15) {
+            document.getElementById('reject-book').disabled = false;
+            $('#reject-book').show();
+        }
         resetMarking();
         removeMarkListener();
     }
@@ -587,36 +591,36 @@
             cancelButtonText: `ยกเลิก`,
             icon: 'question'
         }).then((result) => {
-            if (result.isConfirmed) {
-                $.ajax({
-                    type: "post",
-                    url: "/book/send_to_save",
-                    data: {
-                        id: id,
-                        users_id: users_id,
-                        status: 12,
-                        position_id: position_id
-                    },
-                    dataType: "json",
-                    headers: {
-                        'X-CSRF-TOKEN': '{{ csrf_token() }}'
-                    },
-                    success: function(response) {
+        if (result.isConfirmed) {
+            $.ajax({
+                type: "post",
+                url: "/book/send_to_save",
+                data: {
+                    id: id,
+                    users_id: users_id,
+                    status: 12,
+                    position_id: position_id
+                },
+                dataType: "json",
+                headers: {
+                    'X-CSRF-TOKEN': '{{ csrf_token() }}'
+                },
+                success: function(response) {
+                    if (response.status) {
                         if (response.status) {
-                            if (response.status) {
-                                Swal.fire("", "แทงเรื่องเรียบร้อยแล้ว", "success");
-                                setTimeout(() => {
-                                    location.reload();
-                                }, 1500);
-                            } else {
-                                Swal.fire("", "แทงเรื่องไม่สำเร็จ", "error");
-                            }
+                            Swal.fire("", "แทงเรื่องเรียบร้อยแล้ว", "success");
+                            setTimeout(() => {
+                                location.reload();
+                            }, 1500);
+                        } else {
+                            Swal.fire("", "แทงเรื่องไม่สำเร็จ", "error");
                         }
                     }
-                });
-            }
-        });
+                }
+            });
+        }
     });
+});
     $('#signature-save').click(function(e) {
         e.preventDefault();
         var id = $('#id').val();
@@ -667,6 +671,54 @@
         } else {
             Swal.fire("", "กรุณาเลือกตำแหน่งเกษียณหนังสือ", "info");
         }
+    });
+    $('#reject-book').click(function (e) {
+        e.preventDefault();
+        Swal.fire({
+            title: "",
+            text: "ยืนยันการปฏิเสธหนังสือหรือไม่",
+            icon: "warning",
+            input: 'textarea',
+            inputPlaceholder: 'กรอกเหตุผลการปฏิเสธ',
+            showCancelButton: true,
+            confirmButtonColor: "#3085d6",
+            cancelButtonColor: "#d33",
+            cancelButtonText: "ยกเลิก",
+            confirmButtonText: "ตกลง",
+            preConfirm: (note) => {
+                if (!note) {
+                    Swal.showValidationMessage('กรุณากรอกเหตุผล');
+                }
+                return note;
+            }
+        }).then((result) => {
+            if (result.isConfirmed) {
+                var id = $('#id').val();
+                var note = result.value;
+                $.ajax({
+                    type: "post",
+                    url: "/book/reject",
+                    data: {
+                        id: id,
+                        note: note,
+                    },
+                    dataType: "json",
+                    headers: {
+                        'X-CSRF-TOKEN': '{{ csrf_token() }}'
+                    },
+                    success: function (response) {
+                        if (response.status) {
+                            Swal.fire("", "ปฏิเสธเรียบร้อย", "success");
+                            setTimeout(() => {
+                                location.reload();
+                            }, 1500);
+                        } else {
+                            Swal.fire("", "ปฏิเสธไม่สำเร็จ", "error");
+                        }
+                    }
+                });
+            }
+        });
     });
     $(document).ready(function() {
         $('#manager-sinature').click(function(e) {

--- a/resources/views/book/js/mayor_2.blade.php
+++ b/resources/views/book/js/mayor_2.blade.php
@@ -408,6 +408,10 @@
         if (status == 13) {
             $('#manager-send').show();
         }
+        if (status > 1 && status < 15) {
+            document.getElementById('reject-book').disabled = false;
+            $('#reject-book').show();
+        }
         resetMarking();
         removeMarkListener();
     }
@@ -688,6 +692,55 @@
         $('#insert-pages').click(function(e) {
             e.preventDefault();
             $('#insert_tab').show();
+        });
+
+        $('#reject-book').click(function (e) {
+            e.preventDefault();
+            Swal.fire({
+                title: "",
+                text: "ยืนยันการปฏิเสธหนังสือหรือไม่",
+                icon: "warning",
+                input: 'textarea',
+                inputPlaceholder: 'กรอกเหตุผลการปฏิเสธ',
+                showCancelButton: true,
+                confirmButtonColor: "#3085d6",
+                cancelButtonColor: "#d33",
+                cancelButtonText: "ยกเลิก",
+                confirmButtonText: "ตกลง",
+                preConfirm: (note) => {
+                    if (!note) {
+                        Swal.showValidationMessage('กรุณากรอกเหตุผล');
+                    }
+                    return note;
+                }
+            }).then((result) => {
+                if (result.isConfirmed) {
+                    var id = $('#id').val();
+                    var note = result.value;
+                    $.ajax({
+                        type: "post",
+                        url: "/book/reject",
+                        data: {
+                            id: id,
+                            note: note,
+                        },
+                        dataType: "json",
+                        headers: {
+                            'X-CSRF-TOKEN': '{{ csrf_token() }}'
+                        },
+                        success: function (response) {
+                            if (response.status) {
+                                Swal.fire("", "ปฏิเสธเรียบร้อย", "success");
+                                setTimeout(() => {
+                                    location.reload();
+                                }, 1500);
+                            } else {
+                                Swal.fire("", "ปฏิเสธไม่สำเร็จ", "error");
+                            }
+                        }
+                    });
+                }
+            });
         });
 
         async function createAndRenderPDF() {

--- a/resources/views/book/js/show.blade.php
+++ b/resources/views/book/js/show.blade.php
@@ -590,6 +590,10 @@
                 }
             }
         }
+        if (status > 1 && status < 15) {
+            document.getElementById('reject-book').disabled = false;
+            $('#reject-book').show();
+        }
         // }
         resetMarking();
         removeMarkListener();
@@ -1215,6 +1219,55 @@
     $('#insert-pages').click(function(e) {
         e.preventDefault();
         $('#insert_tab').show();
+    });
+
+    $('#reject-book').click(function (e) {
+        e.preventDefault();
+        Swal.fire({
+            title: "",
+            text: "ยืนยันการปฏิเสธหนังสือหรือไม่",
+            icon: "warning",
+            input: 'textarea',
+            inputPlaceholder: 'กรอกเหตุผลการปฏิเสธ',
+            showCancelButton: true,
+            confirmButtonColor: "#3085d6",
+            cancelButtonColor: "#d33",
+            cancelButtonText: "ยกเลิก",
+            confirmButtonText: "ตกลง",
+            preConfirm: (note) => {
+                if (!note) {
+                    Swal.showValidationMessage('กรุณากรอกเหตุผล');
+                }
+                return note;
+            }
+        }).then((result) => {
+            if (result.isConfirmed) {
+                var id = $('#id').val();
+                var note = result.value;
+                $.ajax({
+                    type: "post",
+                    url: "/book/reject",
+                    data: {
+                        id: id,
+                        note: note,
+                    },
+                    dataType: "json",
+                    headers: {
+                        'X-CSRF-TOKEN': '{{ csrf_token() }}'
+                    },
+                    success: function (response) {
+                        if (response.status) {
+                            Swal.fire("", "ปฏิเสธเรียบร้อย", "success");
+                            setTimeout(() => {
+                                location.reload();
+                            }, 1500);
+                        } else {
+                            Swal.fire("", "ปฏิเสธไม่สำเร็จ", "error");
+                        }
+                    }
+                });
+            }
+        });
     });
 
     $(document).ready(function() {


### PR DESCRIPTION
## Summary
- rollback book status to previous sender when rejected
- clean up obsolete status-16 logic
- expose rejection controls across roles

## Testing
- `npm test`
- `./vendor/bin/phpunit` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689eecb8daf4832983f77bdde4e691ce